### PR TITLE
Feature/use master elevation mapping

### DIFF
--- a/traversability_estimation/config/rosconsole.conf
+++ b/traversability_estimation/config/rosconsole.conf
@@ -1,2 +1,2 @@
-log4j.logger.ros.traversability_estimation=DEBUG
+log4j.logger.ros.traversability_estimation=INFO
 log4j.logger.ros.traversability_estimation_filters=INFO

--- a/traversability_estimation/config/rosconsole.conf
+++ b/traversability_estimation/config/rosconsole.conf
@@ -1,2 +1,2 @@
-log4j.logger.ros.traversability_estimation=INFO
+log4j.logger.ros.traversability_estimation=DEBUG
 log4j.logger.ros.traversability_estimation_filters=INFO

--- a/traversability_estimation/src/TraversabilityEstimation.cpp
+++ b/traversability_estimation/src/TraversabilityEstimation.cpp
@@ -48,7 +48,7 @@ TraversabilityEstimation::TraversabilityEstimation(ros::NodeHandle& nodeHandle)
   imageSubscriber_ = nodeHandle_.subscribe(imageTopic_,1,&TraversabilityEstimation::imageCallback, this);
 
   elevationMapLayers_.push_back("elevation");
-  elevationMapLayers_.push_back("variance");
+  elevationMapLayers_.push_back("upper_bound");
 }
 
 TraversabilityEstimation::~TraversabilityEstimation()
@@ -127,7 +127,7 @@ void TraversabilityEstimation::imageCallback(const sensor_msgs::Image& image)
   if (!getImageCallback_) {
     grid_map::GridMapRosConverter::initializeFromImage(image, imageResolution_, imageGridMap_, imagePosition_);
     ROS_INFO("Initialized map with size %f x %f m (%i x %i cells).", imageGridMap_.getLength().x(), imageGridMap_.getLength().y(), imageGridMap_.getSize()(0), imageGridMap_.getSize()(1));
-    imageGridMap_.add("variance", 0.0); // TODO: Add value for variance.
+    imageGridMap_.add("variance_test_test", 0.0); // TODO: Add value for variance.
     getImageCallback_ = true;
   }
   grid_map::GridMapRosConverter::addLayerFromImage(image, "elevation", imageGridMap_, imageMinHeight_, imageMaxHeight_);

--- a/traversability_estimation/src/TraversabilityEstimation.cpp
+++ b/traversability_estimation/src/TraversabilityEstimation.cpp
@@ -49,6 +49,7 @@ TraversabilityEstimation::TraversabilityEstimation(ros::NodeHandle& nodeHandle)
 
   elevationMapLayers_.push_back("elevation");
   elevationMapLayers_.push_back("upper_bound");
+  elevationMapLayers_.push_back("lower_bound");
 }
 
 TraversabilityEstimation::~TraversabilityEstimation()

--- a/traversability_estimation/src/TraversabilityEstimation.cpp
+++ b/traversability_estimation/src/TraversabilityEstimation.cpp
@@ -128,7 +128,9 @@ void TraversabilityEstimation::imageCallback(const sensor_msgs::Image& image)
   if (!getImageCallback_) {
     grid_map::GridMapRosConverter::initializeFromImage(image, imageResolution_, imageGridMap_, imagePosition_);
     ROS_INFO("Initialized map with size %f x %f m (%i x %i cells).", imageGridMap_.getLength().x(), imageGridMap_.getLength().y(), imageGridMap_.getSize()(0), imageGridMap_.getSize()(1));
-    imageGridMap_.add("variance_test_test", 0.0); // TODO: Add value for variance.
+    imageGridMap_.add("upper_bound", 0.0); // TODO: Add value for layers.
+    imageGridMap_.add("lower_bound", 0.0);
+    imageGridMap_.add("uncertainty_range", imageGridMap_.get("upper_bound") - imageGridMap_.get("lower_bound"));
     getImageCallback_ = true;
   }
   grid_map::GridMapRosConverter::addLayerFromImage(image, "elevation", imageGridMap_, imageMinHeight_, imageMaxHeight_);

--- a/traversability_estimation/src/TraversabilityMap.cpp
+++ b/traversability_estimation/src/TraversabilityMap.cpp
@@ -136,8 +136,10 @@ void TraversabilityMap::publishTraversabilityMap()
   if (!traversabilityMapPublisher_.getNumSubscribers() < 1) {
     grid_map_msgs::GridMap mapMessage;
     boost::recursive_mutex::scoped_lock scopedLockForTraversabilityMap(traversabilityMapMutex_);
-    grid_map::GridMapRosConverter::toMessage(traversabilityMap_, mapMessage);
+    grid_map::GridMap traversabilityMapCopy = traversabilityMap_;
     scopedLockForTraversabilityMap.unlock();
+    traversabilityMapCopy.add("uncertainty_range", traversabilityMapCopy.get("upper_bound") - traversabilityMapCopy.get("lower_bound"));
+    grid_map::GridMapRosConverter::toMessage(traversabilityMapCopy, mapMessage);
     mapMessage.info.pose.position.z = zPosition_;
     traversabilityMapPublisher_.publish(mapMessage);
   }

--- a/traversability_estimation/src/TraversabilityMap.cpp
+++ b/traversability_estimation/src/TraversabilityMap.cpp
@@ -48,7 +48,8 @@ TraversabilityMap::TraversabilityMap(ros::NodeHandle& nodeHandle)
   footprintPublisher_ = nodeHandle_.advertise<geometry_msgs::PolygonStamped>("footprint_polygon", 1, true);
 
   elevationMapLayers_.push_back("elevation");
-  elevationMapLayers_.push_back("variance");
+  elevationMapLayers_.push_back("upper_bound");
+  elevationMapLayers_.push_back("lower_bound");
   // TODO: Adapt map layers to traversability filters.
   traversabilityMapLayers_.push_back(traversabilityType_);
   traversabilityMapLayers_.push_back(slopeType_);


### PR DESCRIPTION


Added layers 'upper_bound', 'lower_bound' and 'uncertainty_range' to grid map and deleted layer 'variance'. This should work with the master of elevation mapping. In addition, the following three steps need to be finished before using the master of elevation_mapping:

1. Merge 'feature/obstacle_detection' into 'master' of navigation.
2. Update the data in /argos_common/argos_navigation_data/elevation_maps/* with the new elevation maps that I created by updating http://anynas.ethz.ch/downloads/argos_common/argos_navigation_data/elevation_maps.tar.gz.
3. Switch 'feature/obstacle_detection' into 'master' of elevation_mapping.

